### PR TITLE
fix(README): Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# aurelia-ssr-boostrapper-webpack
+# aurelia-ssr-bootstrapper-webpack
 
-[![npm Version](https://img.shields.io/npm/v/aurelia-framework.svg)](https://www.npmjs.com/package/aurelia-ssr-boostrapper-webpack)
+[![npm Version](https://img.shields.io/npm/v/aurelia-framework.svg)](https://www.npmjs.com/package/aurelia-ssr-bootstrapper-webpack)
 [![ZenHub](https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png)](https://zenhub.io)
 [![Join the chat at https://gitter.im/aurelia/discuss](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aurelia/discuss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![CircleCI](https://circleci.com/gh/aurelia/ssr-boostrapper-webpack.svg?style=shield)](https://circleci.com/gh/aurelia/ssr-boostrapper-webpack)
+[![CircleCI](https://circleci.com/gh/aurelia/ssr-bootstrapper-webpack.svg?style=shield)](https://circleci.com/gh/aurelia/ssr-bootstrapper-webpack)
 
 This library is part of the [Aurelia](http://www.aurelia.io/) platform and contains the aurelia framework which brings together all the required core aurelia libraries into a ready-to-go application-building platform.
 


### PR DESCRIPTION
This commit fixes the typo of "boostrapper" to "bootstrapper", thus
fixing the link to the npm package and circleCI project.